### PR TITLE
FileWidget no longer sets its own state

### DIFF
--- a/src/components/widgets/FileWidget.js
+++ b/src/components/widgets/FileWidget.js
@@ -75,7 +75,7 @@ class FileWidget extends Component {
     return shouldRender(this, nextProps, nextState);
   }
 
-  onChange = (event) => {
+  onFileChange = (event) => {
     const {multiple, onChange} = this.props;
     processFiles(event.target.files)
       .then((filesInfo) => {
@@ -83,13 +83,11 @@ class FileWidget extends Component {
           values: filesInfo.map(fileInfo => fileInfo.dataURL),
           filesInfo
         };
-        setState(this, state, () => {
-          if (multiple) {
-            onChange(state.values);
-          } else {
-            onChange(state.values[0]);
-          }
-        });
+        if (multiple) {
+          onChange(state.values);
+        } else {
+          onChange(state.values[0]);
+        }
       });
   };
 
@@ -104,7 +102,7 @@ class FileWidget extends Component {
             id={id}
             type="file"
             disabled={readonly || disabled}
-            onChange={this.onChange}
+            onChange={this.onFileChange}
             defaultValue=""
             autoFocus={autofocus}
             multiple={multiple}/>

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -474,10 +474,12 @@ describe("ArrayField", () => {
       });
 
       return new Promise(setImmediate)
-        .then(() => expect(comp.state.formData).eql([
-          "data:text/plain;name=file1.txt;base64,x=",
-          "data:text/plain;name=file2.txt;base64,x=",
-        ]));
+        .then(() => {
+          expect(comp.state.formData).eql([
+            "data:text/plain;name=file1.txt;base64,x=",
+            "data:text/plain;name=file2.txt;base64,x=",
+          ])
+        });
     });
 
     it("should fill field with data", () => {


### PR DESCRIPTION
- all state is held in the Form
- nested promises from setting state in FileWidget were causing test failures

### Reasons for making this change

Get all test green before updating dependencies

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
